### PR TITLE
Fix the issue of occasional failure in Windows CodePatch

### DIFF
--- a/source/InterceptRouting/InterceptRouting.cpp
+++ b/source/InterceptRouting/InterceptRouting.cpp
@@ -65,7 +65,12 @@ void InterceptRouting::Active() {
   void *patch_address = NULL;
   patch_address = (void *)origin_->raw_instruction_start();
 
-  CodePatch(patch_address, (uint8_t *)trampoline_buffer_->getRawBuffer(), trampoline_buffer_->getSize());
+  MemoryOperationError ret = CodePatch(patch_address, (uint8_t *)trampoline_buffer_->getRawBuffer(), trampoline_buffer_->getSize());
+  if (ret != kMemoryOperationSuccess) {
+    DLOG(-1, "[intercept routing] Active patch %p failed", patch_address);
+    return;
+  }
+
   entry_->is_committed = true;
   DLOG(0, "[intercept routing] Active patch %p", patch_address);
 }

--- a/source/UserMode/ExecMemory/code-patch-tool-windows.cc
+++ b/source/UserMode/ExecMemory/code-patch-tool-windows.cc
@@ -150,14 +150,14 @@ static inline void *GetSyscallFunction_x64(uint32_t syscallNum) {
 
 static inline void *GetSyscallFunction_x86(uint32_t syscallNum) {
   uint8_t code[] = {
-      0x64, 0x8B, 0x0D, 0xC0, 0x00, 0x00, 0x00, // +0x00 -> mov ecx, dword ptr fs:[0xC0]
-      0x85, 0xC9,                               // +0x07 -> test ecx, ecx
-      0x75, 0x0A,                               // +0x09 -> jne _wow64
-	  0xBA, 0x00, 0x00, 0x00, 0x00,             // +0x0B -> mov edx, syscallNum
+    0x64, 0x8B, 0x0D, 0xC0, 0x00, 0x00, 0x00, // +0x00 -> mov ecx, dword ptr fs:[0xC0]
+    0x85, 0xC9,                               // +0x07 -> test ecx, ecx
+    0x75, 0x0A,                               // +0x09 -> jne _wow64
+    0xBA, 0x00, 0x00, 0x00, 0x00,             // +0x0B -> mov edx, syscallNum
 	  0xCD, 0x2E,                               // +0x10 -> int 0x2e
 	  0xC3,                                     // +0x12 -> ret
 	  0x33, 0xC9,                               // +0x13 -> xor ecx, ecx
-      0xB8, 0x00, 0x00, 0x00, 0x00,             // +0x15 -> mov eax, syscallNum (_wow64)
+    0xB8, 0x00, 0x00, 0x00, 0x00,             // +0x15 -> mov eax, syscallNum (_wow64)
 	  0x8D, 0x54, 0x24, 0x04,                   // +0x1A -> lea edx, [esp+0x04]
 	  0xFF, 0x11,                               // +0x1E -> call dword ptr [ecx]
 	  0xC3                                      // +0x20 -> ret
@@ -207,7 +207,7 @@ PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t b
   ret = NtProtectVirtualMemory(hProc, &addressPageAlign, &regionSize, newProtect, &oldProtect);
   if (ret != STATUS_SUCCESS) {
     ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
-	  return kMemoryOperationError;
+    return kMemoryOperationError;
   }
 
   memcpy(address, buffer, buffer_size);

--- a/source/UserMode/ExecMemory/code-patch-tool-windows.cc
+++ b/source/UserMode/ExecMemory/code-patch-tool-windows.cc
@@ -1,21 +1,193 @@
 #include "dobby_internal.h"
 
+#define NOMINMAX
 #include <windows.h>
 #include <winternl.h>
 #include <ntstatus.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <fstream>
+
+
+#ifdef _WIN64
+#define GetSyscallFunction GetSyscallFunction_x64
+#else 
+#define GetSyscallFunction GetSyscallFunction_x86
+#endif // _WIN64
 
 using namespace zz;
 
+typedef NTSTATUS(NTAPI *NtProtectVirtualMemoryFunc)(HANDLE ProcessHandle, PVOID *BaseAddress,
+                                                    PSIZE_T NumberOfBytesToProtect, ULONG NewAccessProtection,
+                                                    PULONG OldAccessProtection);
+static NtProtectVirtualMemoryFunc NtProtectVirtualMemory = nullptr;
 
-typedef NTSTATUS(NTAPI* NtProtectVirtualMemoryFunc)(
-    HANDLE ProcessHandle, 
-    PVOID *BaseAddress,                                        
-    PSIZE_T NumberOfBytesToProtect,
-    ULONG NewAccessProtection,
-    PULONG OldAccessProtection
-);
+template <typename T> inline T CastRVATo(void *base, uint32_t offset) {
+  return reinterpret_cast<T>((uint8_t *)(base) + offset);
+}
 
-PUBLIC MemoryOperationError CodePatchNt(void *address, uint8_t *buffer, uint32_t buffer_size) {
+template <typename T> inline T CastFileRVATo(void *base, uint32_t rva) {
+  PIMAGE_DOS_HEADER dosHeader = reinterpret_cast<PIMAGE_DOS_HEADER>(base);
+  PIMAGE_NT_HEADERS ntHeaders = CastRVATo<PIMAGE_NT_HEADERS>(base, dosHeader->e_lfanew);
+  return reinterpret_cast<T>((uint8_t *)(base) + RvaToFileOffset(ntHeaders, rva));
+}
+
+DWORD RvaToFileOffset(PIMAGE_NT_HEADERS ntHeaders, DWORD rva) {
+  PIMAGE_SECTION_HEADER sectionHeader = IMAGE_FIRST_SECTION(ntHeaders);
+  for (int i = 0; i < ntHeaders->FileHeader.NumberOfSections; i++, sectionHeader++) {
+    if (rva >= sectionHeader->VirtualAddress &&
+        rva < (sectionHeader->VirtualAddress + sectionHeader->Misc.VirtualSize)) {
+      return (rva - sectionHeader->VirtualAddress) + sectionHeader->PointerToRawData;
+    }
+  }
+  return 0;
+}
+
+uint32_t GetSyscallNumber() {
+#ifdef _WIN64
+  PPEB peb = (PPEB)__readgsqword(0x60);
+#else
+  PPEB peb = (PPEB)__readfsdword(0x30);
+#endif
+
+  if (!peb) {
+    ERROR_LOG("Failed to get PEB");
+    return 0;
+  }
+
+  PEB_LDR_DATA *ldr = peb->Ldr;
+  if (!ldr) {
+    ERROR_LOG("Failed to get LDR");
+    return 0;
+  }
+
+  PIMAGE_EXPORT_DIRECTORY exportDir = nullptr;
+  void *dllBase = nullptr;
+
+  PLDR_DATA_TABLE_ENTRY ldrEntry;
+  for (ldrEntry = (PLDR_DATA_TABLE_ENTRY)ldr->Reserved2[1]; ldrEntry->DllBase != nullptr;
+       ldrEntry = (PLDR_DATA_TABLE_ENTRY)ldrEntry->Reserved1[0]) {
+    UNICODE_STRING dllName = *reinterpret_cast<UNICODE_STRING *>(&ldrEntry->Reserved4);
+    if (_wcsicmp(dllName.Buffer, L"ntdll.dll") == 0) {
+      break;
+    }
+  }
+
+  if (!ldrEntry->DllBase) {
+    ERROR_LOG("Failed to find ntdll.dll");
+    return 0;
+  }
+
+  std::wstring fullDllName = ldrEntry->FullDllName.Buffer;
+  std::ifstream file(fullDllName, std::ios::binary);
+  if (!file) {
+    ERROR_LOG("Failed to open ntdll.dll");
+    return 0;
+  }
+
+  std::vector<uint8_t> temp((std::istreambuf_iterator<char>(file)), (std::istreambuf_iterator<char>()));
+
+  file.close();
+  dllBase = temp.data();
+
+  // dllBase = ldrEntry->DllBase; // Some process will modify the functions in ntdll.dll when it load into memory
+  PIMAGE_DOS_HEADER dosHeader = reinterpret_cast<PIMAGE_DOS_HEADER>(dllBase);
+  PIMAGE_NT_HEADERS ntHeaders = CastRVATo<PIMAGE_NT_HEADERS>(dllBase, dosHeader->e_lfanew);
+  PIMAGE_DATA_DIRECTORY dataDir = ntHeaders->OptionalHeader.DataDirectory;
+  DWORD virtualAddress = dataDir[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+
+  exportDir = CastFileRVATo<PIMAGE_EXPORT_DIRECTORY>(dllBase, virtualAddress);
+
+  if (!exportDir) {
+    ERROR_LOG("Failed to find export directory");
+    return 0;
+  }
+
+  uint32_t numNames = exportDir->NumberOfNames;
+
+  uint32_t *functions = CastFileRVATo<uint32_t *>(dllBase, exportDir->AddressOfFunctions);
+  uint32_t *names = CastFileRVATo<uint32_t *>(dllBase, exportDir->AddressOfNames);
+  uint16_t *ordinals = CastFileRVATo<uint16_t *>(dllBase, exportDir->AddressOfNameOrdinals);
+  for (uint32_t i = 0; i < numNames; i++) {
+    const char *funcName = CastFileRVATo<const char *>(dllBase, names[i]);
+    if (std::strcmp(funcName, "NtProtectVirtualMemory") != 0)
+      continue;
+
+    uintptr_t address = CastFileRVATo<uintptr_t>(dllBase, functions[ordinals[i]]);
+    // syscallNum = *reinterpret_cast<uint32_t *>(address + SYSCALL_NUMBER_OFFSET);
+    for (int i = 0; i < (0x20 - 0x5); i++) {
+      if (*reinterpret_cast<uint8_t *>(address + i) == 0xb8) {
+        return *reinterpret_cast<uint32_t *>(address + i + 1);
+      }
+    }
+  }
+
+  return 0;
+}
+
+static inline void *GetSyscallFunction_x64(uint32_t syscallNum) {
+  uint8_t code[] = {
+      0x65, 0x48, 0x8b, 0x04, 0x25, 0x60, 0x00, 0x00, 0x00, // +0x00 -> mov rax, gs:[0x60]
+      0x4C, 0x8B, 0xD1,                                     // +0x09 -> xmov r10, rcx
+      0xB8, 0x00, 0x00, 0x00, 0x00,                         // +0x0c -> mov eax, syscallNum
+      0x0f, 0x05,                                           // +0x11 -> syscall
+      0xC3                                                  // +0x13 -> ret
+  };
+
+  *reinterpret_cast<uint32_t *>(code + 0xd) = syscallNum;
+
+  void *exec = VirtualAlloc(NULL, sizeof(code), MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+  if (!exec) {
+	  ERROR_LOG("Failed to allocate memory");
+	  return nullptr;
+  }
+
+  memcpy(exec, code, sizeof(code));
+
+  return exec;
+}
+
+static inline void *GetSyscallFunction_x86(uint32_t syscallNum) {
+  uint8_t code[] = {
+      0x64, 0x8B, 0x0D, 0xC0, 0x00, 0x00, 0x00, // +0x00 -> mov ecx, dword ptr fs:[0xC0]
+      0x85, 0xC9,                               // +0x07 -> test ecx, ecx
+      0x75, 0x0A,                               // +0x09 -> jne _wow64
+	  0xBA, 0x00, 0x00, 0x00, 0x00,             // +0x0B -> mov edx, syscallNum
+	  0xCD, 0x2E,                               // +0x10 -> int 0x2e
+	  0xC3,                                     // +0x12 -> ret
+	  0x33, 0xC9,                               // +0x13 -> xor ecx, ecx
+      0xB8, 0x00, 0x00, 0x00, 0x00,             // +0x15 -> mov eax, syscallNum (_wow64)
+	  0x8D, 0x54, 0x24, 0x04,                   // +0x1A -> lea edx, [esp+0x04]
+	  0xFF, 0x11,                               // +0x1E -> call dword ptr [ecx]
+	  0xC3                                      // +0x20 -> ret
+  };
+
+  *reinterpret_cast<uint32_t *>(code + 0xc) = syscallNum;
+  *reinterpret_cast<uint32_t *>(code + 0x16) = syscallNum;
+
+  void *exec = VirtualAlloc(NULL, sizeof(code), MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+  if (!exec) {
+	  ERROR_LOG("Failed to allocate memory");
+	  return nullptr;
+  }
+
+  memcpy(exec, code, sizeof(code));
+  
+  return exec;
+}
+
+PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t buffer_size) {
+  if (!NtProtectVirtualMemory) {
+    uint32_t syscallNum = GetSyscallNumber();
+    if (syscallNum == 0) {
+      ERROR_LOG("Failed to get syscall number");
+      return kMemoryOperationError;
+    }
+
+    NtProtectVirtualMemory = reinterpret_cast<NtProtectVirtualMemoryFunc>(GetSyscallFunction(syscallNum));
+  }
+
   ULONG oldProtect;
   int pageSize;
 
@@ -25,115 +197,26 @@ PUBLIC MemoryOperationError CodePatchNt(void *address, uint8_t *buffer, uint32_t
 
   void *addressPageAlign = (void *)ALIGN(address, pageSize);
 
-  HMODULE ntdllModule = GetModuleHandle("ntdll.dll");
-  if (ntdllModule == nullptr) {
-    ERROR_LOG("Error failed to get ntdll.dll");
-    return kMemoryOperationError;
-  }
- 
-  NtProtectVirtualMemoryFunc NtProtectVirtualMemory = 
-      (NtProtectVirtualMemoryFunc) GetProcAddress(ntdllModule, "NtProtectVirtualMemory");
-  if (NtProtectVirtualMemory == nullptr) {
-    ERROR_LOG("Error failed to get address of NtProtectVirtualMemory");
-    return kMemoryOperationError;
-  }
-
   NTSTATUS ret;
   SIZE_T regionSize = pageSize;
   ULONG newProtect = PAGE_EXECUTE_READWRITE;
-  HANDLE hp = GetCurrentProcess();
+  HANDLE hProc = GetCurrentProcess();
+  //DWORD pid = GetCurrentProcessId();
+  //HANDLE hProc = OpenProcess(PROCESS_VM_OPERATION, FALSE, pid);
 
-  ret = NtProtectVirtualMemory(hp, &addressPageAlign, &regionSize, newProtect, &oldProtect);
+  ret = NtProtectVirtualMemory(hProc, &addressPageAlign, &regionSize, newProtect, &oldProtect);
+  if (ret != STATUS_SUCCESS) {
+    ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
+	  return kMemoryOperationError;
+  }
+
+  memcpy(address, buffer, buffer_size);
+
+  ret = NtProtectVirtualMemory(hProc, &addressPageAlign, &regionSize, oldProtect, &oldProtect);
   if (ret != STATUS_SUCCESS) {
     ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
     return kMemoryOperationError;
   }
 
-  memcpy(address, buffer, buffer_size);
-
-  ret = NtProtectVirtualMemory(hp, &addressPageAlign, &regionSize, oldProtect, &oldProtect);
-  if (ret != STATUS_SUCCESS) {
-    ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
-    return kMemoryOperationError;
-  }
-
   return kMemoryOperationSuccess;
-}
-
-PUBLIC MemoryOperationError CodePatchEx(void *address, uint8_t *buffer, uint32_t buffer_size) {
-  DWORD oldProtect;
-  int pageSize;
-
-  SYSTEM_INFO si;
-  GetSystemInfo(&si);
-  pageSize = si.dwPageSize;
-
-  void *addressPageAlign = (void *)ALIGN(address, pageSize);
-
-  DWORD pid = GetCurrentProcessId();
-  HANDLE hProcess = OpenProcess(PROCESS_VM_OPERATION, FALSE, pid);
-
-  if (!VirtualProtectEx(hProcess, addressPageAlign, pageSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
-    DWORD err = GetLastError();
-    ERROR_LOG("VirtualProtectEx failed with error coed: 0x%X", err);
-    return kMemoryOperationError;
-  }
-
-  memcpy(address, buffer, buffer_size);
-
-  if (!VirtualProtectEx(hProcess, addressPageAlign, pageSize, oldProtect, &oldProtect)) {
-    DWORD err = GetLastError();
-    ERROR_LOG("VirtualProtectEx failed with error coed: 0x%X", err);
-    return kMemoryOperationError;
-  }
-
-  return kMemoryOperationSuccess;
-}
-
-PUBLIC MemoryOperationError CodePatchStd(void *address, uint8_t *buffer, uint32_t buffer_size) {
-  DWORD oldProtect;
-  int pageSize;
-
-  // Get page size
-  SYSTEM_INFO si;
-  GetSystemInfo(&si);
-  pageSize = si.dwPageSize;
-
-  void *addressPageAlign = (void *)ALIGN(address, pageSize);
-
-  if (!VirtualProtect(addressPageAlign, pageSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
-    DWORD err = GetLastError();
-	ERROR_LOG("VirtualProtect failed with error coed: 0x%X", err);
-	return kMemoryOperationError;
-  }
-    return kMemoryOperationError;
-
-  memcpy(address, buffer, buffer_size);
-
-  if (!VirtualProtect(addressPageAlign, pageSize, oldProtect, &oldProtect)) {
-    DWORD err = GetLastError();
-    ERROR_LOG("VirtualProtect failed with error coed: 0x%X", err);
-    return kMemoryOperationError;
-  }
-    return kMemoryOperationError;
-
-  return kMemoryOperationSuccess;
-}
-
-PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t buffer_size) {
-  MemoryOperationError ret = CodePatchStd(address, buffer, buffer_size);
-
-  // If standard method fails, try using NtProtectVirtualMemory
-  if (ret != kMemoryOperationSuccess) {
-    DLOG(0, "[CodePath] patch %p with VirtualProtect failed, try to patch with NtProtectVirtualMemory", address);
-    ret = CodePatchNt(address, buffer, buffer_size);
-
-    // If NtProtectVirtualMemory also fails, try using VirtualProtectEx
-    if (ret != kMemoryOperationSuccess) {
-      DLOG(0, "[CodePath] patch %p with NtProtectVirtualMemory failed, try to patch with VirtualProtectEx", address);
-      ret = CodePatchEx(address, buffer, buffer_size);
-    }
-  }
-
-  return ret;
 }

--- a/source/UserMode/ExecMemory/code-patch-tool-windows.cc
+++ b/source/UserMode/ExecMemory/code-patch-tool-windows.cc
@@ -1,10 +1,96 @@
 #include "dobby_internal.h"
 
 #include <windows.h>
+#include <winternl.h>
+#include <ntstatus.h>
 
 using namespace zz;
 
-PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t buffer_size) {
+
+typedef NTSTATUS(NTAPI* NtProtectVirtualMemoryFunc)(
+    HANDLE ProcessHandle, 
+    PVOID *BaseAddress,                                        
+    PSIZE_T NumberOfBytesToProtect,
+    ULONG NewAccessProtection,
+    PULONG OldAccessProtection
+);
+
+PUBLIC MemoryOperationError CodePatchNt(void *address, uint8_t *buffer, uint32_t buffer_size) {
+  ULONG oldProtect;
+  int pageSize;
+
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  pageSize = si.dwPageSize;
+
+  void *addressPageAlign = (void *)ALIGN(address, pageSize);
+
+  HMODULE ntdllModule = GetModuleHandle("ntdll.dll");
+  if (ntdllModule == nullptr) {
+    ERROR_LOG("Error failed to get ntdll.dll");
+    return kMemoryOperationError;
+  }
+ 
+  NtProtectVirtualMemoryFunc NtProtectVirtualMemory = 
+      (NtProtectVirtualMemoryFunc) GetProcAddress(ntdllModule, "NtProtectVirtualMemory");
+  if (NtProtectVirtualMemory == nullptr) {
+    ERROR_LOG("Error failed to get address of NtProtectVirtualMemory");
+    return kMemoryOperationError;
+  }
+
+  NTSTATUS ret;
+  SIZE_T regionSize = pageSize;
+  ULONG newProtect = PAGE_EXECUTE_READWRITE;
+  HANDLE hp = GetCurrentProcess();
+
+  ret = NtProtectVirtualMemory(hp, &addressPageAlign, &regionSize, newProtect, &oldProtect);
+  if (ret != STATUS_SUCCESS) {
+    ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
+    return kMemoryOperationError;
+  }
+
+  memcpy(address, buffer, buffer_size);
+
+  ret = NtProtectVirtualMemory(hp, &addressPageAlign, &regionSize, oldProtect, &oldProtect);
+  if (ret != STATUS_SUCCESS) {
+    ERROR_LOG("Error NtProtectVirtualMemory return 0x%X", ret);
+    return kMemoryOperationError;
+  }
+
+  return kMemoryOperationSuccess;
+}
+
+PUBLIC MemoryOperationError CodePatchEx(void *address, uint8_t *buffer, uint32_t buffer_size) {
+  DWORD oldProtect;
+  int pageSize;
+
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  pageSize = si.dwPageSize;
+
+  void *addressPageAlign = (void *)ALIGN(address, pageSize);
+
+  DWORD pid = GetCurrentProcessId();
+  HANDLE hProcess = OpenProcess(PROCESS_VM_OPERATION, FALSE, pid);
+
+  if (!VirtualProtectEx(hProcess, addressPageAlign, pageSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
+    DWORD err = GetLastError();
+    ERROR_LOG("VirtualProtectEx failed with error coed: 0x%X", err);
+    return kMemoryOperationError;
+  }
+
+  memcpy(address, buffer, buffer_size);
+
+  if (!VirtualProtectEx(hProcess, addressPageAlign, pageSize, oldProtect, &oldProtect)) {
+    DWORD err = GetLastError();
+    ERROR_LOG("VirtualProtectEx failed with error coed: 0x%X", err);
+    return kMemoryOperationError;
+  }
+
+  return kMemoryOperationSuccess;
+}
+
+PUBLIC MemoryOperationError CodePatchStd(void *address, uint8_t *buffer, uint32_t buffer_size) {
   DWORD oldProtect;
   int pageSize;
 
@@ -15,13 +101,39 @@ PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t b
 
   void *addressPageAlign = (void *)ALIGN(address, pageSize);
 
-  if (!VirtualProtect(addressPageAlign, pageSize, PAGE_EXECUTE_READWRITE, &oldProtect))
+  if (!VirtualProtect(addressPageAlign, pageSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
+    DWORD err = GetLastError();
+	ERROR_LOG("VirtualProtect failed with error coed: 0x%X", err);
+	return kMemoryOperationError;
+  }
     return kMemoryOperationError;
 
   memcpy(address, buffer, buffer_size);
 
-  if (!VirtualProtect(addressPageAlign, pageSize, oldProtect, &oldProtect))
+  if (!VirtualProtect(addressPageAlign, pageSize, oldProtect, &oldProtect)) {
+    DWORD err = GetLastError();
+    ERROR_LOG("VirtualProtect failed with error coed: 0x%X", err);
+    return kMemoryOperationError;
+  }
     return kMemoryOperationError;
 
   return kMemoryOperationSuccess;
+}
+
+PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t buffer_size) {
+  MemoryOperationError ret = CodePatchStd(address, buffer, buffer_size);
+
+  // If standard method fails, try using NtProtectVirtualMemory
+  if (ret != kMemoryOperationSuccess) {
+    DLOG(0, "[CodePath] patch %p with VirtualProtect failed, try to patch with NtProtectVirtualMemory", address);
+    ret = CodePatchNt(address, buffer, buffer_size);
+
+    // If NtProtectVirtualMemory also fails, try using VirtualProtectEx
+    if (ret != kMemoryOperationSuccess) {
+      DLOG(0, "[CodePath] patch %p with NtProtectVirtualMemory failed, try to patch with VirtualProtectEx", address);
+      ret = CodePatchEx(address, buffer, buffer_size);
+    }
+  }
+
+  return ret;
 }


### PR DESCRIPTION
## Description
Integrate `CodePatch` with `NtProtectVirtualMemory` and `VirtualProtectEx` methods. This enhancement aims to address the issue where the original `CodePatch` fails, prompting it to default to these two alternate methods.



## Motivation and Context
While creating a mod for 'Dave the Diver' using BepInEx, it was observed that even though the program loaded without any error messages, it failed to load any plugins. https://github.com/BepInEx/BepInEx/issues/549  Extensive debugging revealed that Dobby failed to modify protection when using `VirtualProtect`. To resolve this, I substituted the method with `NtProtectVirtualMemory` and `VirtualProtectEx`, and the latter works well.



## Screenshots:
![2023-07-26 21_50_31-Comparing BepInEx_master neeetman_master · BepInEx_Dobby](https://github.com/BepInEx/Dobby/assets/71478917/e026cbae-927c-4cbb-b040-cfc406138a59)
